### PR TITLE
feat: create initial version of resume feedback page with basic layout and section components

### DIFF
--- a/app/features/feedback/ATS.tsx
+++ b/app/features/feedback/ATS.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export default function ATS() {
+  return (
+    <div>ATS</div>
+  )
+}

--- a/app/features/feedback/Details.tsx
+++ b/app/features/feedback/Details.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function Details() {
+  return <div>Details</div>;
+}

--- a/app/features/feedback/Summary.tsx
+++ b/app/features/feedback/Summary.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function Summary() {
+  return <div>Summary</div>;
+}

--- a/app/features/feedback/useResumeData.ts
+++ b/app/features/feedback/useResumeData.ts
@@ -1,0 +1,48 @@
+// src/hooks/useResumeData.ts
+import { useEffect, useState } from "react";
+import { usePuterStore } from "~/lib/puter";
+
+export function useResumeData(id: string | undefined) {
+  const { kv, fs } = usePuterStore();
+  const [resumeUrl, setResumeUrl] = useState("");
+  const [imageUrl, setImageUrl] = useState("");
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (!id) return;
+
+    const loadResume = async () => {
+      try {
+        const resume = await kv.get(`resume:${id}`);
+        if (!resume) return;
+
+        const data = JSON.parse(resume);
+
+        const resumeBlob = await fs.read(data.resumePath);
+        if (!resumeBlob) return;
+        const pdfBlob = new Blob([resumeBlob], { type: "application/pdf" });
+        setResumeUrl(URL.createObjectURL(pdfBlob));
+
+        const imageBlob = await fs.read(data.imagePath);
+        if (!imageBlob) return;
+        setImageUrl(URL.createObjectURL(imageBlob));
+
+        setFeedback(data.feedback);
+      } catch (error) {
+        console.error("Failed to load resume data", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadResume();
+  }, [id]);
+
+  return {
+    resumeUrl,
+    imageUrl,
+    feedback,
+    isLoading,
+  };
+}

--- a/app/features/upload/useAnalyzeResume.ts
+++ b/app/features/upload/useAnalyzeResume.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { useNavigate } from "react-router";
 import { analyzeResume } from "~/lib/services/analyzeResumeService";
 
 export function useAnalyzeResume({
@@ -8,6 +9,7 @@ export function useAnalyzeResume({
   setIsProcessing: (state: boolean) => void;
   setStatusText: (text: string) => void;
 }) {
+  const navigate = useNavigate();
   return useCallback(
     async ({
       file,
@@ -29,6 +31,10 @@ export function useAnalyzeResume({
           jobDescription,
           setStatusText,
         });
+
+        if (result?.id) {
+          navigate(`/resume/${result.id}`);
+        }
         return result;
       } catch (err: any) {
         setStatusText("Error: " + err.message);

--- a/app/lib/services/analyzeResumeService.ts
+++ b/app/lib/services/analyzeResumeService.ts
@@ -123,7 +123,7 @@ export async function analyzeResume({
     setError?.(msg);
     return null;
   }
+  
 
-  console.log("✅ Final Resume Analysis Data:", resumeData);
   return resumeData;
 }

--- a/app/pages/ResumeFeedback.tsx
+++ b/app/pages/ResumeFeedback.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router";
+import ATS from "~/features/feedback/ATS";
+import Details from "~/features/feedback/Details";
+import Summary from "~/features/feedback/Summary";
+import { useResumeData } from "~/features/feedback/useResumeData";
+import { usePuterStore } from "~/lib/puter";
+
+export default function ResumeFeedback() {
+  const navigate = useNavigate();
+  const { auth, isLoading, fs, kv } = usePuterStore();
+  const { id } = useParams();
+  const { resumeUrl, imageUrl, feedback } = useResumeData(id);
+  useEffect(() => {
+    if (isLoading && !auth.isAuthenticated) {
+      navigate(`/auth?next=/resume/${id}`);
+    }
+  }, [isLoading]);
+
+  return (
+    <main className="!pt-0">
+      <nav className="resume-nav">
+        <Link to={"/"} className="back-button">
+          <img src="/icons/back.svg" alt="logo" className="w-2.5 h-2.5" />
+          <span className="text-gray-800 text-sm font-semibold">
+            Back to Home
+          </span>
+        </Link>
+      </nav>
+      <div className="flex flex-row w-full max-lg:flex-col-reverse">
+        <section className="feedback-section bg-[url('/images/bg-small.svg')] bg-cover h-[100vh] sticky top-0 items-center justify-center">
+          {imageUrl && resumeUrl && (
+            <div className="animate-in fade-in duration-1000 gradient-border max-sm:m-0 h-[90%] max-wxl:h-fit w-fit">
+              <a href={resumeUrl} target="_blank" rel="noopener noreferrer">
+                <img
+                  src={imageUrl}
+                  className="w-full h-full object-contain rounded-2xl"
+                  title="resume"
+                />
+              </a>
+            </div>
+          )}
+        </section>
+        <section className="feedback-section">
+          <h2 className="text-4xl !text-black font-bold">Resume Review</h2>
+          {feedback ? (
+            <div className="flex flex-col gap-8 animate-in fade-in">
+              <Summary feedback={feedback} />
+              <ATS
+                score={feedback.ATS.score || 0}
+                suggestions={feedback.ATS.tips || []}
+              />
+              <Details feedback={feedback} />
+            </div>
+          ) : (
+            <img src="/images/resume-scan-2.gif" className="w-full" />
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -4,4 +4,5 @@ export default [
   index("routes/home.tsx"),
   route("/auth", "routes/auth.tsx"),
   route("/upload", "routes/upload.tsx"),
+  route("/resume/:id", "routes/resume.tsx"),
 ] satisfies RouteConfig;

--- a/app/routes/resume.tsx
+++ b/app/routes/resume.tsx
@@ -1,0 +1,15 @@
+import ResumeFeedback from "~/pages/ResumeFeedback";
+import type { Route } from "./+types/resume";
+
+export function meta({}: Route.MetaArgs) {
+  return [
+    { title: "Resumind | Review" },
+    {
+      name: "description",
+      content: "Detailed overview of your resume",
+    },
+  ];
+}
+export default function resume() {
+  return <ResumeFeedback />;
+}

--- a/app/routes/upload.tsx
+++ b/app/routes/upload.tsx
@@ -1,5 +1,15 @@
 import Upload from "~/pages/Upload";
+import type { Route } from "./+types/upload";
 
+export function meta({}: Route.MetaArgs) {
+  return [
+    { title: "Resumind | upload" },
+    {
+      name: "description",
+      content: "Upload your CV and get feedback for your dream job!",
+    },
+  ];
+}
 export default function upload() {
   return <Upload />;
 }


### PR DESCRIPTION
###  Resume Feedback Page (v1)

This PR introduces the **initial version** of the Resume Feedback page. The goal is to establish the structural foundation of the feedback interface using separated and reusable components. No advanced logic is implemented yet—this is a baseline UI version to iterate on.

---

###  What’s included
- `ResumeFeedback.tsx`: main container for the page, composed of sections
- `ATS.tsx`, `Details.tsx`, `Summary.tsx`: minimal presentational components for rendering future AI analysis output
- Basic route setup for navigating to `/resume/:id`
- Simple styling and layout, no conditional logic yet

---

###  Why this matters
This layout sets the stage for visualizing:
- Claude’s AI feedback,
- Resume scoring,
- Section-based improvements,
- PDF/image rendering for resume previews.

---

###  Notes
- `useResumeData` hook is in place to power this page later (already separated for maintainability)
- Next steps will include:
  - Mapping AI feedback to sections
  - Handling edge cases or empty data
  - Visual enhancements and summaries

---

###  How to test
- Navigate to `/resume/:id` with a valid resume ID
- You should see a skeleton page with placeholder components

---

